### PR TITLE
Add Windows WebView2 desktop wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - [Screenshot-Annotator](#screenshot-annotator)
 - [Features](#features)
 - [Quick Start](#quick-start)
+- [Windows wrapper – "Snip & Snatch"](#windows-wrapper--snip--snatch)
 - [Usage](#usage)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
 - [Export and Share](#export-and-share)
@@ -37,6 +38,17 @@ English summary: One-file, no-build image annotator. Open or paste an image, add
 
 Tip: Works offline. Modern browsers recommended (Edge/Chrome/Firefox).
 
+## Windows wrapper – "Snip & Snatch"
+
+Phase 1 of the Windows roadmap is available in `windows/SnipAndSnatch.Desktop`. It's a small WPF/WebView2 host that bundles the existing `index.html` and adds Windows-specific affordances:
+
+- Abrir imagem via diálogo nativo e enviar direto para o canvas
+- Colar do clipboard do Windows (Ctrl+V ou botão dedicado)
+- Arrastar soltar arquivos na janela
+- Passar caminho de arquivo via linha de comando (`SnipAndSnatch.exe c\temp\capture.png`)
+
+Veja `windows/README.md` para requisitos, build (`dotnet publish`) e próximos passos.
+
 ## Usage
 
 - Load image: Use the file input, drag-and-drop, or paste from clipboard.
@@ -66,10 +78,10 @@ Goal: A native-feeling Windows app focused on ultra-fast capture → annotate �
 
 Phases:
 
-1) Wrap current app as desktop (WebView2)
-   - Shell app (WinUI 3 or WPF) hosting `index.html` via WebView2
-   - Single-EXE distribution using self-contained publish
-   - File protocol/IPC to pass captured images into the canvas
+1) Wrap current app as desktop (WebView2) — ✅ disponível em `windows/SnipAndSnatch.Desktop`
+   - [x] Shell app (WPF) hospedando `index.html` via WebView2
+   - [x] Single-EXE distribution via publish self-contained (`dotnet publish` exemplo no README)
+   - [x] File protocol/IPC: abre arquivos, cola do clipboard, drag-and-drop e argumento de linha de comando
 
 2) Snip integration (capture)
    - Use Windows Graphics Capture API for region/window/fullscreen capture

--- a/index.html
+++ b/index.html
@@ -102,7 +102,13 @@
   tools.forEach(b=> b.addEventListener('click', ()=> setTool(b.dataset.tool)));
 
   // Load image
-  function loadImage(src){ const img=new Image(); img.onload=()=>{ state.img=img; setSize(img.naturalWidth, img.naturalHeight); drawBase(); pushHistory(); }; img.src=src; }
+  function loadImage(src){
+    const img=new Image();
+    img.onload=()=>{ state.img=img; setSize(img.naturalWidth, img.naturalHeight); drawBase(); pushHistory(); };
+    img.src=src;
+  }
+  window.SnipAndSnatch = window.SnipAndSnatch || {};
+  window.SnipAndSnatch.loadImage = loadImage;
   file.addEventListener('change', e=>{ const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=> loadImage(r.result); r.readAsDataURL(f) })
   stage.addEventListener('dragover', e=>{ e.preventDefault(); })
   stage.addEventListener('drop', e=>{ e.preventDefault(); const f=e.dataTransfer.files?.[0]; if(f && f.type.startsWith('image/')){ const r=new FileReader(); r.onload=()=> loadImage(r.result); r.readAsDataURL(f) } })
@@ -184,6 +190,14 @@
   exportBtn.addEventListener('click', ()=>{
     const a=document.createElement('a'); a.href=c.toDataURL('image/png'); a.download=`annotated-${Date.now()}.png`; a.click();
   })
+
+  if (window.__snipPending) {
+    const pending = window.__snipPending;
+    window.__snipPending = null;
+    if (pending) {
+      loadImage(pending);
+    }
+  }
 
   // Keyboard shortcuts
   window.addEventListener('keydown', e=>{

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,58 @@
+# Snip & Snatch (Windows wrapper)
+
+A Windows desktop shell that embeds the web-based annotator inside a lightweight WebView2 host.
+
+## Project layout
+
+```
+windows/
+└── SnipAndSnatch.Desktop/
+    ├── App.xaml / App.xaml.cs          # WPF entry point
+    ├── MainWindow.xaml(.cs)            # WebView2 host + shell commands
+    ├── SnipAndSnatch.Desktop.csproj    # .NET 6 WPF project
+    └── SnipAndSnatch.Desktop.sln       # Solution for Visual Studio / Rider
+```
+
+The project copies the repository's root `index.html` into `wwwroot/index.html` at build time so the packaged desktop app stays in sync with the browser version.
+
+## Features implemented (Phase 1 of the roadmap)
+
+- Hosts the existing UI inside Microsoft Edge WebView2.
+- "Abrir imagem..." button loads a file via Windows file picker and injects it into the canvas.
+- "Colar do clipboard" pulls the latest bitmap from the Windows clipboard and sends it straight into the annotator.
+- Drag-and-drop of files directly onto the window.
+- Passing an image path as a command-line argument also preloads the canvas (`SnipAndSnatch.exe path\to\image.png`).
+
+These cover the desktop wrapping + basic IPC items in Phase 1 of the "Snip & Snatch" roadmap. Capture and automation steps remain future work.
+
+## Build and publish
+
+Requirements:
+
+- Windows 10 20H1 (build 19041) or later.
+- .NET 6 SDK (or Visual Studio 2022 with .NET desktop workload).
+
+### Run in Visual Studio
+
+1. Open `SnipAndSnatch.Desktop.sln`.
+2. Restore NuGet packages (WebView2) if prompted.
+3. Set the project as the startup project and press <kbd>F5</kbd>.
+
+### CLI build / single-file publish
+
+```
+dotnet publish windows/SnipAndSnatch.Desktop/SnipAndSnatch.Desktop.csproj \
+  -c Release \
+  -r win-x64 \
+  --self-contained true \
+  -p:PublishSingleFile=true \
+  -p:IncludeNativeLibrariesForSelfExtract=true
+```
+
+The publish output contains a self-contained `SnipAndSnatch.exe` that you can distribute. WebView2 runtime is required on the target machine (installed with recent Edge versions).
+
+## Next steps
+
+- Hook Windows Graphics Capture to feed screenshots directly into `PushOrQueueAsync`.
+- Add automation hooks (e.g., clipboard monitoring, "Send to AI" shortcuts).
+- Share a packaged download via GitHub Releases.

--- a/windows/SnipAndSnatch.Desktop/App.xaml
+++ b/windows/SnipAndSnatch.Desktop/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="SnipAndSnatch.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+  <Application.Resources>
+  </Application.Resources>
+</Application>

--- a/windows/SnipAndSnatch.Desktop/App.xaml.cs
+++ b/windows/SnipAndSnatch.Desktop/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace SnipAndSnatch;
+
+public partial class App : Application
+{
+}

--- a/windows/SnipAndSnatch.Desktop/MainWindow.xaml
+++ b/windows/SnipAndSnatch.Desktop/MainWindow.xaml
@@ -1,0 +1,60 @@
+<Window x:Class="SnipAndSnatch.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        mc:Ignorable="d"
+        Title="Snip &amp; Snatch"
+        Height="720"
+        Width="1200"
+        MinHeight="600"
+        MinWidth="800" AllowDrop="True"
+        PreviewDragOver="OnPreviewDragOver"
+        Drop="OnDrop">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+
+    <Border Grid.Row="0"
+            Background="#11141c"
+            Padding="12"
+            BorderBrush="#1f2432"
+            BorderThickness="0,0,0,1">
+      <DockPanel LastChildFill="False">
+        <StackPanel Orientation="Horizontal"
+                    DockPanel.Dock="Left"
+                    Margin="0,0,24,0"
+                    VerticalAlignment="Center">
+          <Button x:Name="OpenButton"
+                  Width="120"
+                  Margin="0,0,8,0"
+                  Content="Abrir imagem..."
+                  Click="OnOpenImage" />
+          <Button x:Name="PasteButton"
+                  Width="120"
+                  Margin="0,0,8,0"
+                  Content="Colar do clipboard"
+                  Click="OnPasteImage" />
+          <Button x:Name="ReloadButton"
+                  Width="96"
+                  Content="Recarregar"
+                  Click="OnReload" />
+        </StackPanel>
+        <TextBlock Foreground="#9aa3b7"
+                   VerticalAlignment="Center"
+                   Text="Snip &amp; Snatch — captura, anote e cole (fase 1)" />
+      </DockPanel>
+    </Border>
+
+    <wv2:WebView2 x:Name="WebView"
+                  Grid.Row="1"
+                  Margin="0"
+                  AllowDrop="True"
+                  PreviewDragOver="OnPreviewDragOver"
+                  Drop="OnDrop"
+                  DefaultBackgroundColor="#00000000" />
+  </Grid>
+</Window>

--- a/windows/SnipAndSnatch.Desktop/MainWindow.xaml.cs
+++ b/windows/SnipAndSnatch.Desktop/MainWindow.xaml.cs
@@ -1,0 +1,245 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Win32;
+
+namespace SnipAndSnatch;
+
+public partial class MainWindow : Window
+{
+    private bool _webReady;
+    private string? _pendingDataUrl;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+
+        CommandBindings.Add(new CommandBinding(ApplicationCommands.Paste, async (_, __) => await LoadClipboardImageAsync(), (_, e) => e.CanExecute = true));
+        InputBindings.Add(new KeyBinding(ApplicationCommands.Paste, new KeyGesture(Key.V, ModifierKeys.Control)));
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await WebView.EnsureCoreWebView2Async();
+            WebView.NavigationCompleted += OnNavigationCompleted;
+
+            var indexPath = Path.Combine(AppContext.BaseDirectory, "wwwroot", "index.html");
+            if (File.Exists(indexPath))
+            {
+                WebView.CoreWebView2.Navigate(new Uri(indexPath).AbsoluteUri);
+            }
+            else
+            {
+                MessageBox.Show(this, "index.html não encontrado no diretório wwwroot.", "Snip & Snatch", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            await TryLoadInitialArgumentAsync();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Falha ao inicializar o WebView2: {ex.Message}", "Snip & Snatch", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private async void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
+    {
+        if (!e.IsSuccess)
+        {
+            MessageBox.Show(this, $"Falha ao carregar a UI: {e.WebErrorStatus}", "Snip & Snatch", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        _webReady = true;
+        WebView.NavigationCompleted -= OnNavigationCompleted;
+
+        if (_pendingDataUrl is not null)
+        {
+            var pending = _pendingDataUrl;
+            _pendingDataUrl = null;
+            await PushImageToCanvasAsync(pending);
+        }
+    }
+
+    private async Task TryLoadInitialArgumentAsync()
+    {
+        var args = Environment.GetCommandLineArgs();
+        if (args.Length <= 1)
+        {
+            return;
+        }
+
+        foreach (var candidate in args.Skip(1))
+        {
+            if (!File.Exists(candidate))
+            {
+                continue;
+            }
+
+            var dataUrl = await GetDataUrlFromFileAsync(candidate);
+            await PushOrQueueAsync(dataUrl);
+            break;
+        }
+    }
+
+    private async Task PushOrQueueAsync(string dataUrl)
+    {
+        if (_webReady && WebView.CoreWebView2 is not null)
+        {
+            await PushImageToCanvasAsync(dataUrl);
+        }
+        else
+        {
+            _pendingDataUrl = dataUrl;
+        }
+    }
+
+    private async Task PushImageToCanvasAsync(string dataUrl)
+    {
+        if (WebView.CoreWebView2 is null)
+        {
+            _pendingDataUrl = dataUrl;
+            return;
+        }
+
+        var payload = JsonSerializer.Serialize(dataUrl);
+        await WebView.CoreWebView2.ExecuteScriptAsync($@"(function(){{const src={payload};
+  if(window.loadImage){{ window.loadImage(src); }}
+  else if(window.SnipAndSnatch && window.SnipAndSnatch.loadImage){{ window.SnipAndSnatch.loadImage(src); }}
+  else {{ window.__snipPending = src; }}
+}})();");
+    }
+
+    private static async Task<string> GetDataUrlFromFileAsync(string path)
+    {
+        var bytes = await File.ReadAllBytesAsync(path);
+        var mime = GetMimeType(path);
+        return $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
+    }
+
+    private static string GetMimeType(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".bmp" => "image/bmp",
+            ".tif" or ".tiff" => "image/tiff",
+            ".webp" => "image/webp",
+            ".heic" => "image/heic",
+            _ => "image/png"
+        };
+    }
+
+    private async Task LoadClipboardImageAsync()
+    {
+        try
+        {
+            if (!Clipboard.ContainsImage())
+            {
+                MessageBox.Show(this, "Nenhuma imagem encontrada no clipboard.", "Snip & Snatch", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var image = Clipboard.GetImage();
+            if (image is null)
+            {
+                MessageBox.Show(this, "Não foi possível ler a imagem do clipboard.", "Snip & Snatch", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            using var stream = new MemoryStream();
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(image));
+            encoder.Save(stream);
+            var bytes = stream.ToArray();
+            var dataUrl = $"data:image/png;base64,{Convert.ToBase64String(bytes)}";
+            await PushOrQueueAsync(dataUrl);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Erro ao acessar o clipboard: {ex.Message}", "Snip & Snatch", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    private async void OnOpenImage(object sender, RoutedEventArgs e)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Filter = "Imagens|*.png;*.jpg;*.jpeg;*.gif;*.bmp;*.tif;*.tiff;*.webp;*.heic|Todos os arquivos|*.*"
+        };
+
+        if (dialog.ShowDialog(this) == true)
+        {
+            var dataUrl = await GetDataUrlFromFileAsync(dialog.FileName);
+            await PushOrQueueAsync(dataUrl);
+        }
+    }
+
+    private async void OnPasteImage(object sender, RoutedEventArgs e)
+    {
+        await LoadClipboardImageAsync();
+    }
+
+    private void OnReload(object sender, RoutedEventArgs e)
+    {
+        if (WebView.CoreWebView2 is null)
+        {
+            return;
+        }
+
+        _webReady = false;
+        WebView.NavigationCompleted += OnNavigationCompleted;
+        WebView.Reload();
+    }
+
+    private void OnPreviewDragOver(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(DataFormats.FileDrop))
+        {
+            var files = (string[]?)e.Data.GetData(DataFormats.FileDrop);
+            if (files?.Any(IsSupportedImage) == true)
+            {
+                e.Effects = DragDropEffects.Copy;
+                e.Handled = true;
+                return;
+            }
+        }
+
+        e.Effects = DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private async void OnDrop(object sender, DragEventArgs e)
+    {
+        if (!e.Data.GetDataPresent(DataFormats.FileDrop))
+        {
+            return;
+        }
+
+        var files = (string[]?)e.Data.GetData(DataFormats.FileDrop);
+        var candidate = files?.FirstOrDefault(IsSupportedImage);
+        if (candidate is null)
+        {
+            return;
+        }
+
+        var dataUrl = await GetDataUrlFromFileAsync(candidate);
+        await PushOrQueueAsync(dataUrl);
+    }
+
+    private static bool IsSupportedImage(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext is ".png" or ".jpg" or ".jpeg" or ".gif" or ".bmp" or ".tif" or ".tiff" or ".webp" or ".heic";
+    }
+}

--- a/windows/SnipAndSnatch.Desktop/SnipAndSnatch.Desktop.csproj
+++ b/windows/SnipAndSnatch.Desktop/SnipAndSnatch.Desktop.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationIcon></ApplicationIcon>
+    <RootNamespace>SnipAndSnatch</RootNamespace>
+    <AssemblyName>SnipAndSnatch</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2420.47" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\index.html">
+      <Link>wwwroot\index.html</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/windows/SnipAndSnatch.Desktop/SnipAndSnatch.Desktop.sln
+++ b/windows/SnipAndSnatch.Desktop/SnipAndSnatch.Desktop.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34024.191
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SnipAndSnatch", "SnipAndSnatch.Desktop.csproj", "{C6F93ED3-7BFE-458B-A72B-B323F6D12341}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{C6F93ED3-7BFE-458B-A72B-B323F6D12341}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{C6F93ED3-7BFE-458B-A72B-B323F6D12341}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{C6F93ED3-7BFE-458B-A72B-B323F6D12341}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{C6F93ED3-7BFE-458B-A72B-B323F6D12341}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add a `windows/SnipAndSnatch.Desktop` WPF project that hosts the existing annotator via WebView2 with file dialog, clipboard, drag-and-drop and command-line injection support
- expose a stable `SnipAndSnatch.loadImage` hook and pending-image fallback in `index.html` for the desktop host
- document the new Windows wrapper in the README and mark the first roadmap phase as delivered

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf7c48a420832ba95b2414ca4b2a25